### PR TITLE
Changed "attribute-name.class.pug" class statements

### DIFF
--- a/extensions/pug/syntaxes/pug.tmLanguage.json
+++ b/extensions/pug/syntaxes/pug.tmLanguage.json
@@ -239,7 +239,7 @@
 					"name": "entity.other.attribute-name.id.pug"
 				},
 				"3": {
-					"name": "entity.other.attribute-name.class.pug"
+					"name": "entity.other.attribute-name.class.css"
 				},
 				"4": {
 					"name": "meta.tag.other entity.name.tag.pug"
@@ -632,7 +632,7 @@
 					"name": "invalid.illegal.tag.pug"
 				}
 			},
-			"name": "entity.other.attribute-name.class.pug"
+			"name": "entity.other.attribute-name.class.css"
 		},
 		"tag_attributes": {
 			"begin": "(\\(\\s*)",


### PR DESCRIPTION
Because of inappropriate syntax highlights, "attribute-name.class.pug" shoud be changed to "attribute-name.class.css".
"attribute-name.class.pug" causes applying the same color to represent ID and class.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #113205
